### PR TITLE
fix(this): remove reference to `this`

### DIFF
--- a/src/core/VtkSyncView.js
+++ b/src/core/VtkSyncView.js
@@ -219,7 +219,7 @@ export default {
         client.value
           .getConnection()
           .getSession()
-          .unsubscribe(this.wsSubscription);
+          .unsubscribe(wsSubscription);
         wsSubscription = null;
       }
 


### PR DESCRIPTION
It is not needed here, and it produces an error.