### PR TITLE
feat: add WebXR helper component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@kitware/vtk.js": "29.4.5",
+        "@kitware/vtk.js": "32.2.0",
         "@vitejs/plugin-vue": "^4.0.0"
       },
       "devDependencies": {
@@ -2227,9 +2227,10 @@
       }
     },
     "node_modules/@kitware/vtk.js": {
-      "version": "29.4.5",
-      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-29.4.5.tgz",
-      "integrity": "sha512-71Pp78fIdN8vjdexGCc+sTV/td/izxxNJ13S0x45p0zNQXJBWtmln597uZeLToJ4qtszTiWWsF6KnFWVoc/5OA==",
+      "version": "32.2.0",
+      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-32.2.0.tgz",
+      "integrity": "sha512-CIU0fPP9dxJ0ByLvkHr///bGn40o4kQI9nN3yWRSQVh1UVdSnooorKScLGE6bPHcqn0V7BlhF4y3N+XxSDHD6Q==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "7.22.11",
         "@types/webxr": "^0.5.5",
@@ -2255,7 +2256,7 @@
       "peerDependencies": {
         "@babel/preset-env": "^7.17.10",
         "autoprefixer": "^10.4.7",
-        "wslink": "^1.1.0"
+        "wslink": ">=1.1.0 || ^2.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -12101,9 +12102,9 @@
       }
     },
     "@kitware/vtk.js": {
-      "version": "29.4.5",
-      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-29.4.5.tgz",
-      "integrity": "sha512-71Pp78fIdN8vjdexGCc+sTV/td/izxxNJ13S0x45p0zNQXJBWtmln597uZeLToJ4qtszTiWWsF6KnFWVoc/5OA==",
+      "version": "32.2.0",
+      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-32.2.0.tgz",
+      "integrity": "sha512-CIU0fPP9dxJ0ByLvkHr///bGn40o4kQI9nN3yWRSQVh1UVdSnooorKScLGE6bPHcqn0V7BlhF4y3N+XxSDHD6Q==",
       "requires": {
         "@babel/runtime": "7.22.11",
         "@types/webxr": "^0.5.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "semantic-release": "semantic-release"
   },
   "dependencies": {
-    "@kitware/vtk.js": "29.4.5",
+    "@kitware/vtk.js": "32.2.0",
     "@vitejs/plugin-vue": "^4.0.0"
   },
   "peerDependencies": {

--- a/src/components.js
+++ b/src/components.js
@@ -13,6 +13,7 @@ import VtkRemoteLocalView from "./core/VtkRemoteLocalView";
 import VtkRemoteView from "./core/VtkRemoteView";
 import VtkSyncView from "./core/VtkSyncView";
 import VtkView from "./core/VtkView";
+import VtkWebXRHelper from "./core/VtkWebXRHelper";
 
 export default {
   VtkAlgorithm,
@@ -31,4 +32,5 @@ export default {
   VtkSyncView,
   VtkLocalView: VtkSyncView,
   VtkView,
+  VtkWebXRHelper,
 };

--- a/src/core/VtkView.js
+++ b/src/core/VtkView.js
@@ -124,6 +124,7 @@ export default {
       props.interactorEvents,
       { emit, nextTick }
     );
+    view.setCubeAxesVisibility(props.showCubeAxes);
     const { onEnter, onLeave, onKeyUp } = enableResetCamera(view);
     const resizeObserver = new ResizeObserver(() => view.resize());
 
@@ -149,12 +150,19 @@ export default {
       () => props.pickingModes,
       () => (view.pickingModes = props.pickingModes)
     );
+    watch(
+      () => props.showCubeAxes,
+      () => view.setCubeAxesVisibility(props.showCubeAxes)
+    );
 
     provide("view", view);
     const { onClick, onMouseMove } = view;
     const resetCamera = () => view.resetCamera();
     const getCamera = () => view.getCamera();
     const setCamera = (v) => view.setCamera(v);
+    const setCubeAxesVisibility = (v) => {
+      props.showCubeAxes = v;
+    };
     return {
       vtkContainer,
       onEnter,
@@ -164,6 +172,7 @@ export default {
       resetCamera,
       getCamera,
       setCamera,
+      setCubeAxesVisibility,
     };
   },
   template: `

--- a/src/core/VtkWebXRHelper.js
+++ b/src/core/VtkWebXRHelper.js
@@ -1,0 +1,72 @@
+import { inject } from "vue";
+import vtkResourceLoader from "@kitware/vtk.js/IO/Core/ResourceLoader";
+import vtkWebXRRenderWindowHelper from "@kitware/vtk.js/Rendering/WebXR/RenderWindowHelper";
+import vtkInteractorStyleHMDXR from "@kitware/vtk.js/Interaction/Style/InteractorStyleHMDXR";
+
+export default {
+  props: {
+    drawControllersRay: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ["enterXR", "exitXR"],
+  setup(props, { attrs, emit }) {
+    // Dynamically load WebXR polyfill from CDN for WebVR and Cardboard API backwards compatibility
+    if (navigator.xr === undefined) {
+      vtkResourceLoader
+        .loadScript(
+          "https://cdn.jsdelivr.net/npm/webxr-polyfill@latest/build/webxr-polyfill.js"
+        )
+        .then(() => {
+          // eslint-disable-next-line no-new, no-undef
+          new WebXRPolyfill();
+        });
+    }
+
+    // WebXR helper from VTK.js
+    const XRHelper = vtkWebXRRenderWindowHelper.newInstance();
+    const view = inject("view");
+
+    const startXR = () => {
+      // Returns if we're using an unsupported view (RemoteView)
+      if (!view || !view.openglRenderWindow) {
+        console.error("WebXR is not supported by VtkRemoteView");
+        return;
+      }
+      XRHelper.setRenderWindow(view.openglRenderWindow);
+      XRHelper.setDrawControllersRay(props.drawControllersRay);
+
+      // Setup interactor style HMDXR
+      attrs.oldInteractorStyle = view.renderWindow
+        .getInteractor()
+        .getInteractorStyle();
+      view.renderWindow
+        .getInteractor()
+        .setInteractorStyle(vtkInteractorStyleHMDXR.newInstance());
+
+      XRHelper.startXR();
+      emit("enterXR");
+    };
+    const stopXR = () => {
+      // Returns if we're using an unsupported view (RemoteView)
+      if (!view || !view.openglRenderWindow) {
+        console.error("WebXR is not supported by VtkRemoteView");
+        return;
+      }
+
+      // Revert interactor style
+      view.renderWindow
+        .getInteractor()
+        .setInteractorStyle(attrs.oldInteractorStyle);
+
+      XRHelper.stopXR();
+      emit("exitXR");
+    };
+
+    return {
+      startXR,
+      stopXR,
+    };
+  },
+};

--- a/src/core/localview.js
+++ b/src/core/localview.js
@@ -561,7 +561,6 @@ export class ClientView {
       .getActors()
       .forEach(({ setVisibility }) => setVisibility(false));
 
-    this.cubeAxes.setCamera(this.activeCamera);
     this.renderer.addActor(this.cubeAxes);
 
     const bbox = vtkBoundingBox.newInstance({ bounds: [0, 0, 0, 0, 0, 0] });
@@ -704,6 +703,15 @@ export class ClientView {
       }
       this.vueCtx.nextTick(this.render);
     }
+  }
+
+  setCubeAxesVisibility(isVisible) {
+    this.cubeAxes.setVisibility(isVisible);
+    this.cubeAxes
+      .getActors()
+      .forEach(({ setVisibility }) => setVisibility(isVisible));
+    this.cubeAxes.setCamera(isVisible ? this.activeCamera : null); // WebXRHelper compatibility (see PR #9)
+    this.vueCtx.nextTick(this.render);
   }
 
   updateStyle(settings) {


### PR DESCRIPTION
Context:
I want to make a trame-vtk widget to support WebXR in Trame.
Here's the trame-vtk PR: https://github.com/Kitware/trame-vtk/pull/81

This PR:
- changes vtk.js version from 29.4.5 to 32.2.0 to benefit from the WebXR helper. Ideally, the new vtk.js version should include this small fix: https://github.com/Kitware/vtk-js/pull/3220
- adds a new vue component that enables VtkView and VtkSyncView to be used for a WebXR session.
 
This component is a wrapper for vtk.js' `vtkWebXRRenderWindowHelper`. It has two methods `startXR` and `stopXR` and can trigger `enterXR` and `exitXR` events. `drawControllersRay` can be set to true to draw rays to represent the controllers.

To make the WebXR view work with a VtkView, I had to comment a line in `ClientView` (last commit). I don't really understand what it does and I get the same results with and without it. @jourdain : do you know what's the purpose of the "Cube axes" section ? I don't understand why it's there since its visibility is always false and it makes the WebXR helper mess with the transform matrix...
